### PR TITLE
Fix annapurnanepal to annapurnasilnepal

### DIFF
--- a/data/fallback.json
+++ b/data/fallback.json
@@ -309,7 +309,7 @@
             "roles": {
                 "default": [
                     "annapurnasil",
-                    "annapurnanepal",
+                    "annapurnasilnepal",
                     "notosansdevanagari",
                     "notoserifdevanagari"
                 ]

--- a/testdata/fontrules.json
+++ b/testdata/fontrules.json
@@ -6352,7 +6352,7 @@
         "roles": {
           "default": [
             "annapurnasil",
-            "annapurnanepal",
+            "annapurnasilnepal",
             "notosansdevanagari",
             "notoserifdevanagari"
           ]


### PR DESCRIPTION
In one place an old `annapurnanepal` remains, though it should be `annapurnasilnepal`: https://github.com/silnrsi/fonts/blob/main/basefiles/annapurnasilnepal_base.json